### PR TITLE
Use diego logging client in place of compatibility

### DIFF
--- a/benchmark_bbs_suite_test.go
+++ b/benchmark_bbs_suite_test.go
@@ -25,7 +25,7 @@ import (
 	"code.cloudfoundry.org/benchmarkbbs/reporter"
 	"code.cloudfoundry.org/cfhttp"
 	"code.cloudfoundry.org/clock"
-	fakes "code.cloudfoundry.org/go-loggregator/testhelpers/fakes/v1"
+	fakes "code.cloudfoundry.org/diego-logging-client/testhelpers"
 	"code.cloudfoundry.org/lager"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"


### PR DESCRIPTION
This work upgrades Diego to use go-loggregator v3.0.0. It also encapsulates Diego's use of the loggregator client behind a single interface found in `diego-logging-client` within `diego-release`.

By wrapping go-loggregator in Diego, we ensure future upgrades to go-loggregator will not require such large change sets.

This PR goes hand in hand with the following PRs:
- [diego-release](https://github.com/cloudfoundry/diego-release/pull/349)
- [auctioneer](https://github.com/cloudfoundry/auctioneer/pull/6)
- [bbs](https://github.com/cloudfoundry/bbs/pull/24)
- [locket](https://github.com/cloudfoundry/locket/pull/3)
- [rep](https://github.com/cloudfoundry/rep/pull/17)
- [executor](https://github.com/cloudfoundry/executor/pull/27)
- [volman](https://github.com/cloudfoundry/volman/pull/4)

[#148451433]

Signed-off-by: Jason Keene <jkeene@pivotal.io>