### PR TITLE
Use jackc/pgx instead of lib/pq

### DIFF
--- a/benchmark_bbs_suite_test.go
+++ b/benchmark_bbs_suite_test.go
@@ -153,7 +153,7 @@ func initializeActiveDB() *sql.DB {
 		config.DatabaseConnectionString = fmt.Sprintf("%s?sslmode=disable", config.DatabaseConnectionString)
 	}
 
-	sqlConn, err := sql.Open(config.DatabaseDriver, config.DatabaseConnectionString)
+	sqlConn, err := helpers.Connect(logger, config.DatabaseDriver, config.DatabaseConnectionString, "", false)
 	if err != nil {
 		logger.Fatal("failed-to-open-sql", err)
 	}


### PR DESCRIPTION
The pq library is in maintainance mode according ot the repository's
[README](https://github.com/lib/pq/tree/f3b22b2cad9e4567803b7ffd9853b8acda021438).

> This package is effectively in maintenance mode and is not actively
> developed. Small patches and features are only rarely reviewed and merged. We
> recommend using pgx which is actively maintained.